### PR TITLE
Add open and close group states (for moveit2 gripper contorl)

### DIFF
--- a/src/cello_moveit_config/config/camera_with_stand.xacro
+++ b/src/cello_moveit_config/config/camera_with_stand.xacro
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" >
+
+    <xacro:macro name="camera_with_stand" params="camera_pos_z camera_type:=realsense">
+        <!-- Variables -->
+        <xacro:property name="pi_val" value="3.1415926535"/>
+
+        <!-- Materials -->
+        <material name="gray">
+            <color rgba="0.5 0.5 0.5 1" />
+        </material>
+
+        <!-- Include realsense urdf macro -->
+        <xacro:if value="${camera_type == 'realsense'}">
+            <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro"/>
+        </xacro:if>
+
+        <!-- Links -->
+        <link name="camera_base_link"/>
+
+        <xacro:if value="${camera_type != 'realsense'}">
+            <link name="camera_link">
+                <visual>
+                    <origin xyz="0 0 -0.015" rpy="0 0 0"/>
+                    <geometry>
+                        <cylinder radius="0.03" length="0.03"/>
+                    </geometry>
+                    <material name="gray"/>
+                </visual>
+            </link>
+        </xacro:if>
+
+        <link name="camera_holder_upper_arm_link">
+            <visual>
+                <origin xyz="0.015 0 -0.15" rpy="0 0 0"/>
+                <geometry>
+                    <box size="0.03 0.03 0.3"/>
+                </geometry>
+                <material name="gray"/>
+            </visual>
+            <collision>
+                <origin xyz="0 0 -0.15" rpy="0 0 0"/>
+                <geometry>
+                    <box size="0.03 0.03 0.3"/>
+                </geometry>
+            </collision>
+        </link>
+
+        <link name="camera_holder_lower_arm_link">
+            <visual>
+                <origin xyz="${camera_pos_z/2} 0 0.015" rpy="0 0 0"/>
+                <geometry>
+                    <box size="${camera_pos_z} 0.03 0.03"/>
+                </geometry>
+                <material name="gray"/>
+            </visual>
+            <collision>
+                <origin xyz="${camera_pos_z/2} 0 0.015" rpy="0 0 0"/>
+                <geometry>
+                    <box size="${camera_pos_z} 0.03 0.03"/>
+                </geometry>
+            </collision>
+        </link>
+
+        <link name="camera_holder_base">
+            <visual>
+                <geometry>
+                    <cylinder radius="0.08" length="0.01" />
+                </geometry>
+                <origin xyz="0 0 -0.005" rpy="0 0 0" />
+                <material name="gray" />
+            </visual>
+        </link>
+
+
+        <!-- Joints -->
+        <xacro:if value="${camera_type == 'realsense'}">
+            <xacro:sensor_d435i parent="camera_base_link" use_nominal_extrinsics="true" >
+                <origin xyz="0.0095 0 -0.0125" rpy="0 0 0"/>
+            </xacro:sensor_d435i>
+        </xacro:if>
+
+        <xacro:if value="${camera_type != 'realsense'}">
+            <joint name="camera_base_to_camera_joint" type="fixed">
+                <parent link="camera_base_link"/>
+                <child link="camera_link"/>
+                <origin xyz="0 0 0" rpy="0 ${pi_val/2} 0"/>
+            </joint>
+        </xacro:if>
+        
+        <joint name="camera_base_to_upper_arm_joint" type="fixed">
+            <parent link="camera_base_link"/>
+            <child link="camera_holder_upper_arm_link"/>
+            <origin xyz="-0.03 0 0.0125" rpy="0 0 0"/>
+        </joint>
+
+        <joint name="camera_holder_upper_arm_to_camera_holder_lower_arm_joint" type="fixed">
+            <parent link="camera_holder_upper_arm_link"/>
+            <child link="camera_holder_lower_arm_link"/>
+            <origin xyz="0.03 0 -0.3" rpy="0 0 0"/>
+        </joint>
+
+        <joint name="camera_holder_lower_arm_to_camera_holder_base_joint" type="fixed">
+            <parent link="camera_holder_lower_arm_link"/>
+            <child link="camera_holder_base"/>
+            <origin xyz="${camera_pos_z} 0 0.015" rpy="0 ${pi_val/2} 0"/>
+        </joint>
+    </xacro:macro>
+
+</robot>

--- a/src/cello_moveit_config/config/cello_description.srdf
+++ b/src/cello_moveit_config/config/cello_description.srdf
@@ -33,6 +33,13 @@
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="hand" parent_link="link5" group="hand"/>
+    <!--GROUP STATES: define open and close for the hand-->
+    <group_state name="close" group="hand">
+        <joint name="joint7_left" value="0"/>
+    </group_state>
+    <group_state name="open" group="hand">
+        <joint name="joint7_left" value="-0.025"/>
+    </group_state>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="base_link"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->

--- a/src/cello_moveit_config/config/cello_description.srdf
+++ b/src/cello_moveit_config/config/cello_description.srdf
@@ -25,11 +25,35 @@
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="arm">
         <joint name="joint1" value="0"/>
+        <joint name="joint2" value="-1.4"/>
+        <joint name="joint3" value="1.4"/>
+        <joint name="joint4" value="0"/>
+        <joint name="joint5" value="0"/>
+        <joint name="joint6" value="0"/>
+    </group_state>
+    <group_state name="zero" group="arm">
+        <joint name="joint1" value="0"/>
         <joint name="joint2" value="0"/>
         <joint name="joint3" value="0"/>
         <joint name="joint4" value="0"/>
         <joint name="joint5" value="0"/>
         <joint name="joint6" value="0"/>
+    </group_state>
+    <group_state name="pose_1" group="arm">
+        <joint name="joint1" value="-0.4189"/>
+        <joint name="joint2" value="0.4887"/>
+        <joint name="joint3" value="0.1571"/>
+        <joint name="joint4" value="-0.0349"/>
+        <joint name="joint5" value="0.9250"/>
+        <joint name="joint6" value="-0.4014"/>
+    </group_state>
+    <group_state name="pose_2" group="arm">
+        <joint name="joint1" value="0.3316"/>
+        <joint name="joint2" value="0.1745"/>
+        <joint name="joint3" value="0.1745"/>
+        <joint name="joint4" value="-0.01745"/>
+        <joint name="joint5" value="1.2392"/>
+        <joint name="joint6" value="0.3316"/>
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="hand" parent_link="link5" group="hand"/>

--- a/src/cello_moveit_config/config/cello_description.srdf
+++ b/src/cello_moveit_config/config/cello_description.srdf
@@ -34,10 +34,10 @@
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="hand" parent_link="link5" group="hand"/>
     <!--GROUP STATES: define open and close for the hand-->
-    <group_state name="close" group="hand">
+    <group_state name="open" group="hand">
         <joint name="joint7_left" value="0"/>
     </group_state>
-    <group_state name="open" group="hand">
+    <group_state name="close" group="hand">
         <joint name="joint7_left" value="-0.025"/>
     </group_state>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->

--- a/src/cello_moveit_config/config/cello_description.srdf
+++ b/src/cello_moveit_config/config/cello_description.srdf
@@ -40,19 +40,19 @@
         <joint name="joint6" value="0"/>
     </group_state>
     <group_state name="pose_1" group="arm">
-        <joint name="joint1" value="-0.4189"/>
-        <joint name="joint2" value="0.4887"/>
-        <joint name="joint3" value="0.1571"/>
-        <joint name="joint4" value="-0.0349"/>
-        <joint name="joint5" value="0.9250"/>
-        <joint name="joint6" value="-0.4014"/>
-    </group_state>
-    <group_state name="pose_2" group="arm">
         <joint name="joint1" value="-0.4188"/>
         <joint name="joint2" value="0.3141"/>
         <joint name="joint3" value="0.0523"/>
         <joint name="joint4" value="-0.0349"/>
         <joint name="joint5" value="1.2217"/>
+        <joint name="joint6" value="-0.4014"/>
+    </group_state>
+    <group_state name="pose_2" group="arm">
+        <joint name="joint1" value="-0.4189"/>
+        <joint name="joint2" value="0.4887"/>
+        <joint name="joint3" value="0.1571"/>
+        <joint name="joint4" value="-0.0349"/>
+        <joint name="joint5" value="0.9250"/>
         <joint name="joint6" value="-0.4014"/>
     </group_state>
     <group_state name="pose_3" group="arm">
@@ -61,6 +61,14 @@
         <joint name="joint3" value="0.1745"/>
         <joint name="joint4" value="-0.01745"/>
         <joint name="joint5" value="1.2392"/>
+        <joint name="joint6" value="0.3316"/>
+    </group_state>
+    <group_state name="pose_4" group="arm">
+        <joint name="joint1" value="0.3316"/>
+        <joint name="joint2" value="0.3839"/>
+        <joint name="joint3" value="0.3316"/>
+        <joint name="joint4" value="0.0"/>
+        <joint name="joint5" value="0.8726"/>
         <joint name="joint6" value="0.3316"/>
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->

--- a/src/cello_moveit_config/config/cello_description.srdf
+++ b/src/cello_moveit_config/config/cello_description.srdf
@@ -48,6 +48,14 @@
         <joint name="joint6" value="-0.4014"/>
     </group_state>
     <group_state name="pose_2" group="arm">
+        <joint name="joint1" value="-0.4188"/>
+        <joint name="joint2" value="0.3141"/>
+        <joint name="joint3" value="0.0523"/>
+        <joint name="joint4" value="-0.0349"/>
+        <joint name="joint5" value="1.2217"/>
+        <joint name="joint6" value="-0.4014"/>
+    </group_state>
+    <group_state name="pose_3" group="arm">
         <joint name="joint1" value="0.3316"/>
         <joint name="joint2" value="0.1745"/>
         <joint name="joint3" value="0.1745"/>

--- a/src/cello_moveit_config/config/cello_description.urdf.xacro
+++ b/src/cello_moveit_config/config/cello_description.urdf.xacro
@@ -1,6 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="cello_description">
+
+    <!-- Arguments -->
     <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
+
+    <xacro:arg name="launch_camera" default="false" />
+    <xacro:arg name="camera_type" default="realsense" />
+    <xacro:arg name="camera_pos_x" default="0.25" />
+    <xacro:arg name="camera_pos_y" default="0.0" />
+    <xacro:arg name="camera_pos_z" default="0.4" />
+    <xacro:arg name="camera_pos_roll" default="0.0" />
+    <xacro:arg name="camera_pos_pitch" default="1.57079633" />
+    <xacro:arg name="camera_pos_yaw" default="3.14159265" />
 
     <!-- Import cello_description urdf file -->
     <xacro:include filename="$(find cello_description)/urdf/cello_description.urdf" />
@@ -8,7 +19,20 @@
     <!-- Import control_xacro -->
     <xacro:include filename="cello_description.ros2_control.xacro" />
 
-
     <xacro:cello_description_ros2_control name="FakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
+
+    <!-- Conditionally include control if not GUI -->
+    <xacro:if value="$(eval launch_camera)">
+        <xacro:include filename="$(find cello_moveit_config)/config/camera_with_stand.xacro"/>
+        <xacro:camera_with_stand camera_pos_z="$(arg camera_pos_z)" camera_type="$(arg camera_type)" />
+
+        <!-- Connect camera to robot base -->
+        <joint name="base_link_camera_base_joint" type="fixed">
+            <parent link="base_link"/>
+            <child link="camera_base_link"/>
+            <origin xyz="$(arg camera_pos_x) $(arg camera_pos_y) $(arg camera_pos_z)" 
+                    rpy="$(arg camera_pos_roll) $(arg camera_pos_pitch) $(arg camera_pos_yaw)"/>
+        </joint>
+    </xacro:if>
 
 </robot>

--- a/src/cello_moveit_config/config/moveit_servo.yaml
+++ b/src/cello_moveit_config/config/moveit_servo.yaml
@@ -1,0 +1,57 @@
+###############################################
+# Modify all parameters related to servoing here
+###############################################
+
+use_gazebo: false
+
+## Properties of incoming commands
+command_in_type: "unitless"
+scale:
+  # Max linear velocity. Unit is [m/s].
+  linear: 0.10
+  # Max angular velocity. Unit is [rad/s].
+  rotational: 0.25
+  # Max joint angular/linear velocity.
+  joint: 0.50
+
+## Properties of outgoing commands
+publish_period: 0.02
+low_latency_mode: false
+command_out_type: trajectory_msgs/JointTrajectory
+publish_joint_positions: true
+publish_joint_velocities: true
+publish_joint_accelerations: false
+smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
+is_primary_planning_scene_monitor: true
+
+## MoveIt properties
+move_group_name: arm
+planning_frame: world
+
+## Other frames
+ee_frame_name: link6
+robot_link_command_frame: link6
+
+## Stopping behaviour
+incoming_command_timeout: 0.1
+num_outgoing_halt_msgs_to_publish: 4
+
+## Configure handling of singularities and joint limits
+lower_singularity_threshold: 17.0
+hard_stop_singularity_threshold: 30.0
+joint_limit_margin: 0.1
+leaving_singularity_threshold_multiplier: 2.0
+
+## Topic names
+cartesian_command_in_topic: ~/delta_twist_cmds
+joint_command_in_topic: ~/delta_joint_cmds
+pose_command_in_topic: ~/pose_target
+joint_topic: /joint_states
+status_topic: ~/status
+command_out_topic: /arm_controller/joint_trajectory
+
+## Collision checking
+check_collisions: true
+collision_check_rate: 10.0
+self_collision_proximity_threshold: 0.01
+scene_collision_proximity_threshold: 0.02

--- a/src/cello_moveit_config/launch/servo.launch.py
+++ b/src/cello_moveit_config/launch/servo.launch.py
@@ -1,0 +1,71 @@
+import os
+import yaml
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    moveit_config = MoveItConfigsBuilder(
+        "cello_description", package_name="cello_moveit_config"
+    ).to_moveit_configs()
+
+    pkg_share = get_package_share_directory("cello_moveit_config")
+    ros2_controllers_path = os.path.join(pkg_share, "config", "ros2_controllers.yaml")
+    servo_params_path = os.path.join(pkg_share, "config", "moveit_servo.yaml")
+    with open(servo_params_path, "r", encoding="utf-8") as f:
+        servo_yaml = yaml.safe_load(f) or {}
+    servo_params = {"moveit_servo": servo_yaml}
+
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        output="both",
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster", "-c", "/controller_manager"],
+        output="screen",
+    )
+
+    arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["arm_controller", "-c", "/controller_manager"],
+        output="screen",
+    )
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[moveit_config.robot_description],
+    )
+
+    servo_node = Node(
+        package="moveit_servo",
+        executable="servo_node_main",
+        name="servo_node",
+        output="screen",
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics,
+            servo_params,
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            robot_state_publisher,
+            ros2_control_node,
+            joint_state_broadcaster_spawner,
+            arm_controller_spawner,
+            servo_node,
+        ]
+    )

--- a/src/cello_moveit_config/launch/servo_rviz.launch.py
+++ b/src/cello_moveit_config/launch/servo_rviz.launch.py
@@ -1,0 +1,87 @@
+import os
+import yaml
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    moveit_config = MoveItConfigsBuilder(
+        "cello_description", package_name="cello_moveit_config"
+    ).to_moveit_configs()
+
+    pkg_share = get_package_share_directory("cello_moveit_config")
+    ros2_controllers_path = os.path.join(pkg_share, "config", "ros2_controllers.yaml")
+    servo_params_path = os.path.join(pkg_share, "config", "moveit_servo.yaml")
+    with open(servo_params_path, "r", encoding="utf-8") as f:
+        servo_yaml = yaml.safe_load(f) or {}
+    servo_params = {"moveit_servo": servo_yaml}
+    rviz_config_path = os.path.join(pkg_share, "config", "moveit.rviz")
+
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        output="both",
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster", "-c", "/controller_manager"],
+        output="screen",
+    )
+
+    arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["arm_controller", "-c", "/controller_manager"],
+        output="screen",
+    )
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[moveit_config.robot_description],
+    )
+
+    servo_node = Node(
+        package="moveit_servo",
+        executable="servo_node_main",
+        name="servo_node",
+        output="screen",
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics,
+            servo_params,
+        ],
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_path],
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.planning_pipelines,
+            moveit_config.robot_description_kinematics,
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            robot_state_publisher,
+            ros2_control_node,
+            joint_state_broadcaster_spawner,
+            arm_controller_spawner,
+            servo_node,
+            rviz_node,
+        ]
+    )

--- a/src/cello_moveit_config/package.xml
+++ b/src/cello_moveit_config/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_ros_warehouse</exec_depend>
+  <exec_depend>moveit_servo</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/src/cello_moveit_config/package.xml
+++ b/src/cello_moveit_config/package.xml
@@ -43,7 +43,8 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/src/viola_moveit_config/config/viola_description.srdf
+++ b/src/viola_moveit_config/config/viola_description.srdf
@@ -33,6 +33,13 @@
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="hand" parent_link="link5" group="hand"/>
+    <!--GROUP STATES: define open and close for the hand-->
+    <group_state name="close" group="hand">
+        <joint name="joint7_left" value="0"/>
+    </group_state>
+    <group_state name="open" group="hand">
+        <joint name="joint7_left" value="-0.025"/>
+    </group_state>    
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="base_link"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->

--- a/src/viola_moveit_config/package.xml
+++ b/src/viola_moveit_config/package.xml
@@ -42,7 +42,8 @@
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>viola_description</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
 
 
   <export>


### PR DESCRIPTION
For some of the moveit2 functionalities you need `open` and `close` gripper states to be defined in the srdf